### PR TITLE
Bring back --strict action functionality + keep exit code

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,12 @@ This action takes same input arguments as the [composer-diff command](https://gi
 
   Follows same convention as `base` argument
 - `format` - output format - either `mdtable`, `mdlist` or `json` - see [composer-diff documentation](https://github.com/IonBazan/composer-diff#usage) - default: `mdtable`
+- `strict` - returns non-zero exit code if there are any changes - default: `false`
 - `no-dev` - excludes dev dependencies - default: `false`
 - `no-prod` - excludes prod dependencies - default: `false`
 - `with-platform` - include platform (`php`, `ext-*`) dependencies - default: `false`
 - `with-links` - adds compare/release URLs - default: `false`
 - `extra-arguments` - additional arguments to be passed to the command - default: `--ansi` (for colorful output)
-
-This actions always run in a `strict` mode, so the result of the command execution is available further on. 
 
 ## Outputs
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,21 +1,22 @@
-#!/bin/sh
+#!/bin/bash
+
+ARGS=$*
+OUTPUT=$(composer diff --strict $ARGS)
+EXIT_CODE=$?
 
 set -e
 
-OUTPUT=$(composer diff --strict $*)
-EXIT_CODE=$?
+echo "$OUTPUT"
 
-if [ $EXIT_CODE -eq 0 ]; then
-  echo "::set-output name=composer_diff::"
-else
-  echo "$OUTPUT"
+OUTPUT=$(echo -n "$OUTPUT" | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g')
+OUTPUT="${OUTPUT//'%'/'%25'}"
+OUTPUT="${OUTPUT//$'\n'/'%0A'}"
+OUTPUT="${OUTPUT//$'\r'/'%0D'}"
 
-  OUTPUT=$(echo "$OUTPUT" | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g')
-  OUTPUT="${OUTPUT//'%'/'%25'}"
-  OUTPUT="${OUTPUT//$'\n'/'%0A'}"
-  OUTPUT="${OUTPUT//$'\r'/'%0D'}"
-
-  echo "::set-output name=composer_diff::$OUTPUT"
-fi
+echo -n "::set-output name=composer_diff::$OUTPUT"
 
 echo "::set-output name=composer_diff_exit_code::$EXIT_CODE"
+
+if [[ "--strict" =~ .*"$ARGS".* ]]; then
+  exit $EXIT_CODE
+fi


### PR DESCRIPTION
Changes here:

- do not exit too early (move `set -e` a bit lower)
- exit with a non-zero code when asked too (bring back `--strict`)
- run using `/bin/bash` instead of `/bin/sh` so `echo -n` can be used, which omits printing the new line character
- use `echo -n` for result assignment => no new line
- return exit code