### PR TITLE
Fix formatting

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,13 +10,12 @@ set -e
 
 echo "$OUTPUT"
 
-OUTPUT=$(echo -n "$OUTPUT" | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g')
-OUTPUT="${OUTPUT//'%'/'%25'}"
-OUTPUT="${OUTPUT//$'\n'/'%0A'}"
-OUTPUT="${OUTPUT//$'\r'/'%0D'}"
-
 echo "composer_diff_exit_code=$EXIT_CODE" >> $GITHUB_OUTPUT
-echo -n "composer_diff=$OUTPUT" >> $GITHUB_OUTPUT
+
+delimiter="$(openssl rand -hex 8)"
+echo "composer_diff<<${delimiter}" >> "${GITHUB_OUTPUT}"
+echo "${OUTPUT}" >> "${GITHUB_OUTPUT}"
+echo "${delimiter}" >> "${GITHUB_OUTPUT}"
 
 if [[ "$*" == *"--strict"* ]]; then
   exit $EXIT_CODE


### PR DESCRIPTION
Updated multiline string saving while using the `GITHUB_OUTPUT` file. ([Ref](https://github.com/orgs/community/discussions/26288#discussioncomment-3876281))

#### [Before](https://github.com/NoResponseMate/TestComposerDiffAction/pull/4):
<img width="607" alt="image" src="https://user-images.githubusercontent.com/9448101/198983276-24f06469-9b8e-419b-bd9e-68a736266fba.png">

#### [After](https://github.com/NoResponseMate/TestComposerDiffAction/pull/3):
<img width="608" alt="image" src="https://user-images.githubusercontent.com/9448101/198983324-eadca0ba-489d-4fb5-84ac-885436aa9a41.png">
